### PR TITLE
Remove localStorage migration from DocumentManager and DatabaseService

### DIFF
--- a/src/services/DatabaseService.js
+++ b/src/services/DatabaseService.js
@@ -128,38 +128,5 @@ export const DatabaseService = {
       console.error(`Error deleting document with id ${id}:`, error);
       return false;
     }
-  },
-
-  /**
-   * Migrate data from localStorage to PouchDB
-   * @returns {Promise<boolean>} Promise resolving to success status
-   */
-  migrateFromLocalStorage: async () => {
-    try {
-      const STORAGE_KEY = 'commad-documents';
-      const localStorageData = localStorage.getItem(STORAGE_KEY);
-      
-      if (!localStorageData) {
-        return true; // Nothing to migrate
-      }
-      
-      const documents = JSON.parse(localStorageData);
-      
-      // Save each document to PouchDB
-      for (const doc of documents) {
-        await DatabaseService.saveDocument({
-          ...doc,
-          _id: doc.id // PouchDB uses _id as the primary key
-        });
-      }
-      
-      // Optional: Clear localStorage after successful migration
-      // localStorage.removeItem(STORAGE_KEY);
-      
-      return true;
-    } catch (error) {
-      console.error('Error migrating from localStorage:', error);
-      return false;
-    }
   }
 };

--- a/src/services/DocumentManager.js
+++ b/src/services/DocumentManager.js
@@ -12,10 +12,9 @@ const DEFAULT_DOCUMENT = {
   updatedAt: new Date().toISOString()
 };
 
-// Initialize database and migrate data
+// Initialize database
 (async () => {
   await DatabaseService.init();
-  await DatabaseService.migrateFromLocalStorage();
 })();
 
 export const DocumentManager = {


### PR DESCRIPTION
Eliminate the localStorage migration functionality from both DocumentManager and DatabaseService to streamline the initialization process.